### PR TITLE
Re-PR, FIX Negative precision in Axis labels format

### DIFF
--- a/src/graph/LinearTicks.php
+++ b/src/graph/LinearTicks.php
@@ -273,7 +273,9 @@ class LinearTicks extends Ticks
                 }
             }
         } else {
-            $l = sprintf('%01.' . $precision . 'f', round($aVal, $precision));
+            //FIX: if negative precision  is returned "0f" , instead of formatted values
+            $format = $precision>0?'%01.' . $precision . 'f':'%01.0f';
+            $l =  sprintf($format, round($aVal, $precision));
         }
 
         if (($this->supress_zerolabel && $l == 0) || ($this->supress_first && $aIdx == 0) || ($this->supress_last && $aIdx == $aNbrTicks - 1)) {


### PR DESCRIPTION
Re-PR, I take into account your comments and remove unnecessary commits

FIX Negative precision in Axis labels format: example returned "0f" , instead of formatted values.

Before:
![iprcurve before](https://cloud.githubusercontent.com/assets/9015003/15426287/3506e27c-1e96-11e6-9dc4-8cf9fed67e8f.png)
After:
![iprcurve after](https://cloud.githubusercontent.com/assets/9015003/15426290/389867f8-1e96-11e6-9f53-6b39786e5a10.png)
