### PR TITLE
Remove setting error_reporting

### DIFF
--- a/src/includes/jpgraph.php
+++ b/src/includes/jpgraph.php
@@ -1,7 +1,4 @@
 <?php
-error_reporting(E_ALL);
-ini_set("display_errors", 1);
-
 //=======================================================================
 // File:        JPGRAPH.PHP
 // Description: PHP Graph Plotting library. Base module.


### PR DESCRIPTION
When using the Graph class error_reporting and display_errors get overwritten to E_ALL and true, which is very undesirable, especially for production. 

Removing this should change nothing when using JPGraph and only lead to a better experience. I suspect this was included to find a bug originally but then forgotten - typical debug mistake. I only noticed it because I kept getting Exceptions for E_NOTICE.