### PR TITLE
Fixes 'class Util\JpGraphError not found' in Plot class

### DIFF
--- a/src/graph/Graph.php
+++ b/src/graph/Graph.php
@@ -2575,6 +2575,10 @@ class Graph
     // Get Y min and max values for added lines
     public function GetLinesYMinMax($aLines)
     {
+        if(is_null($aLines)) {
+          return false;
+        }
+
         $n = count($aLines);
         if ($n == 0) {
             return false;

--- a/src/plot/Plot.php
+++ b/src/plot/Plot.php
@@ -2,6 +2,8 @@
 
 namespace Amenadiel\JpGraph\Plot;
 
+use Amenadiel\JpGraph\Util;
+
 //===================================================
 // CLASS Plot
 // Description: Abstract base class for all concrete plot classes


### PR DESCRIPTION
Adds 'use Amenadiel\JpGraph\Util' to Plot.php so exceptions are properly thrown.