### PR TITLE
Fix polyfill error with Kint dependency

### DIFF
--- a/src/includes/polyfills.php
+++ b/src/includes/polyfills.php
@@ -25,7 +25,9 @@ if (!class_exists('\Kint')) {
         public static $enabled_mode     = true;
         public static $aliases          = [];
         public static $mode_default_cli = false;
-        public static function dump() {}
+        public static function dump()
+        {
+        }
     }
 }
 if (class_exists('\Kint\Renderer\RichRenderer')) {
@@ -43,7 +45,9 @@ if (!class_exists('\PhpConsole\Handler')) {
      */
     class PC
     {
-        public static function debug() {}
+        public static function debug()
+        {
+        }
     }
 }
 function ddd(...$vars)

--- a/src/includes/polyfills.php
+++ b/src/includes/polyfills.php
@@ -22,9 +22,9 @@ if (!class_exists('\Kint')) {
      */
     class Kint
     {
-        public static $enabled_mode = true;
-        public static $aliases      = [];
-
+        public static $enabled_mode     = true;
+        public static $aliases          = [];
+        public static $mode_default_cli = false;
         public static function dump() {}
     }
 }


### PR DESCRIPTION
The kint mocking class was missing a public static field ($mode_default_cli) that was accessed just a few lines afterward. 