### PR TITLE
Fix PHP8 notice for object to int conversion

### DIFF
--- a/src/image/Image.php
+++ b/src/image/Image.php
@@ -140,7 +140,7 @@ class Image
         }
 
         $this->img = @imagecreatetruecolor($aWidth, $aHeight);
-        if ($this->img < 1) {
+        if ($this->img === false) {
             Util\JpGraphError::RaiseL(25126);
             //die("Can't create truecolor image. Check that you really have GD2 library installed.");
         }


### PR DESCRIPTION
PHP8 emits the notice "Notice: Object of class GdImage could not be converted to int" when comparing the result of imagecreatetruecolor with an int. imagecreatetruecolor returns false on any errors, so a strict comparison to false is more sensible and works in both PHP7 and PHP8.

This fixes https://github.com/HuasoFoundries/jpgraph/issues/99.