### PR TITLE
Fix: Warning was triggered when we had slice colors but no CSIM targets

### DIFF
--- a/src/plot/PiePlot.php
+++ b/src/plot/PiePlot.php
@@ -392,10 +392,11 @@ class PiePlot
                 $wintarg = $this->csimwintargets[$i];
             }
 
+            $imageMapTarget = $this->csimtargets[$i] ?? '';
             if ($this->setslicecolors == null) {
-                $graph->legend->Add($l, $colors[$ta[$i % $numcolors]], '', 0, $this->csimtargets[$i], $alt, $wintarg);
+                $graph->legend->Add($l, $colors[$ta[$i % $numcolors]], '', 0, $imageMapTarget, $alt, $wintarg);
             } else {
-                $graph->legend->Add($l, $this->setslicecolors[$i % $numcolors], '', 0, $this->csimtargets[$i], $alt, $wintarg);
+                $graph->legend->Add($l, $this->setslicecolors[$i % $numcolors], '', 0, $imageMapTarget, $alt, $wintarg);
             }
         }
     }


### PR DESCRIPTION
Whenever we `SetSliceColors` and don't `SetCSIMTargets` (which seems to be optional), we would get a warning. This commit should fix it.