### PR TITLE
Fix: Pushing scrutinizer PHP version to 7.4. 7.1 is deprecated.

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -3,7 +3,7 @@ checks:
 build:
     environment:
           php:
-            version: '7.1'
+            version: '7.4'
             ini:
                 'zend_extension': 'xdebug.so'
     nodes:


### PR DESCRIPTION
In the near future this should be pushed to PHP8