### PR TITLE
PiePlot PHP 7.4 fix

### DIFF
--- a/src/plot/PiePlot.php
+++ b/src/plot/PiePlot.php
@@ -395,7 +395,7 @@ class PiePlot
             if ($this->setslicecolors == null) {
                 $graph->legend->Add($l, $colors[$ta[$i % $numcolors]], '', 0, $this->csimtargets[$i], $alt, $wintarg);
             } else {
-                $graph->legend->Add($l, $this->setslicecolors[$i % $numcolors], '', 0, $this->csimtargets[$i], $alt, $wintarg);
+                $graph->legend->Add($l, $this->setslicecolors[$i % $numcolors], '', 0, ($this->csimtargets[$i] ?? null), $alt, $wintarg);
             }
         }
     }


### PR DESCRIPTION
Fixes the PHP 7.4 error: "Trying to access array offset on value of type null"