### PR TITLE
repair cache mechanism by early exit for cache hit

### DIFF
--- a/src/image/ImgStreamCache.php
+++ b/src/image/ImgStreamCache.php
@@ -184,7 +184,7 @@ class ImgStreamCache
     public function GetAndStream($aImage, $aCacheFileName)
     {
         if ($this->Isvalid($aCacheFileName)) {
-            $this->StreamImgFile($aImage, $aCacheFileName);
+            return $this->StreamImgFile($aImage, $aCacheFileName);
         } else {
             return false;
         }


### PR DESCRIPTION
Return return value of `StreamImgFile` to calling function, otherwise cache functionality will not work, because `exit` in `Graph.php:201` is never reached and the functionality of skipping calculations as described in https://jpgraph.net/download/manuals/chunkhtml/ch09s03.html not achieved and therefore the cache mechanism useless.