### PR TITLE
Deprecation notices float to int loses precision in PHP 8.1 

### DIFF
--- a/src/image/Image.php
+++ b/src/image/Image.php
@@ -1046,8 +1046,8 @@ class Image
                 }
             }
 
-            $x = round($x);
-            $y = round($y);
+            $x = (int) round($x);
+            $y = (int) round($y);
 
             imagettftext(
                 $this->img,
@@ -1160,8 +1160,8 @@ class Image
                 $yl = $y - $yadj;
                 //$xl = $xl- $xadj;
 
-                $xl = round($xl);
-                $yl = round($yl - ($h - $fh) + $fh * $i);
+                $xl = (int) round($xl);
+                $yl = (int) round($yl - ($h - $fh) + $fh * $i);
 
                 imagettftext(
                     $this->img,

--- a/src/image/Image.php
+++ b/src/image/Image.php
@@ -1045,6 +1045,10 @@ class Image
                     // Do nothing the text is drawn at baseline by default
                 }
             }
+
+            $x = round($x);
+            $y = round($y);
+
             imagettftext(
                 $this->img,
                 $this->font_size,
@@ -1155,12 +1159,16 @@ class Image
                 $xl -= $bbox[0] / 2;
                 $yl = $y - $yadj;
                 //$xl = $xl- $xadj;
+
+                $xl = round($xl);
+                $yl = round($yl - ($h - $fh) + $fh * $i);
+
                 imagettftext(
                     $this->img,
                     $this->font_size,
                     $dir,
                     $xl,
-                    $yl - ($h - $fh) + $fh * $i,
+                    $yl,
                     $this->current_color,
                     $this->font_file,
                     $tmp[$i]


### PR DESCRIPTION
To avoid deprecation log on implicit conversion, the method **_StrokeTTF** should always give int to **imagettftext**.

The function, **imagettftext**, expects type int on parameters x and y.
https://www.php.net/manual/es/function.imagettftext.php

**Example deprecation log:**
```error
PHP message: PHP Deprecated:  Implicit conversion from float 64.5 to int loses precision in /vendor/amenadiel/jpgraph/src/image/Image.php on line 1049
```

PHP version: PHP 8.1.5 (cli) (built: May  3 2022 09:22:01) (NTS)